### PR TITLE
PNDA-4851: Bulk Ingest via KNOX proxy

### DIFF
--- a/bulkingest/README.md
+++ b/bulkingest/README.md
@@ -3,21 +3,22 @@
 The `ingest.sh` shell script is used to ingest data onto a PNDA cluster.
 
 ## Install
-
-To install dependencies and configure the tool for an HttpFS endpoint, run the `install` command with the IP address of a node running `HttpFS` role and port 14000. 
+To install dependencies and configure the tool through secured KNOX gateway, run the `install` command with the KNOX Gateway URL
 
 ```
- ingest.sh install http://host:port
- e.g 
- ingest.sh install http://192.168.0.0:14000
+ ingest.sh install https://<knox FQDN>:<port>/gateway/<topology_name> <path_to_CA_root_certificate>
+ e.g
+ ingest.sh install https://knox.service.dc1.pnda.local:8443/gateway/pnda /root/pndaproject/pnda-cli/platform-certificates/pndaproject-ca.crt
 ```
+For SSL certificate verification, enter the path to root CA certificate(This certificate can be retrieved from "pnda-cli/platform-certificates/pndaproject-ca.crt")
 
 Please check with your cluster administrator for the correct IP address and port, as it may change in production deployments. 
 
 ## Upload
 
 To upload file or directory onto a cluster, run the `upload` command with the dir/file name. 
-You can use the `-f` flag to overwrite existing files, and `-t number of threads` for parallelism.  
+You can use the `-f` flag to overwrite existing files, and `-t number of threads` for parallelism.
+It prompts to enter username & password for Knox gateway authentication
  
 ```
 ingest.sh upload localfile or local_directory

--- a/bulkingest/hdfscli.py
+++ b/bulkingest/hdfscli.py
@@ -1,0 +1,23 @@
+from hdfs import Client
+import requests
+import base64
+
+class SecureClient(Client):
+
+  """A new client subclass for handling HTTPS connections.
+
+  :param url: URL to namenode.
+  :param cert: Local certificate. See `requests` documentation for details
+    on how to use this.
+  :param verify: Whether to check the host's certificate.
+  :param \*\*kwargs: Keyword arguments passed to the default `Client`
+    constructor.
+
+  """
+  def __init__(self, url, verify=None, user=None, password=None, **kwargs):
+    session = requests.Session()
+    user = base64.b64decode(user)
+    password = base64.b64decode(password)
+    session.auth = (user, password)
+    session.verify = verify
+    super(SecureClient, self).__init__(url, session=session, **kwargs)


### PR DESCRIPTION
Updated platform-tools to include secure client to communicate with HTTPFS via the gateway

Modified ingest.sh to include secure client parameters in HDFS CLI configuration file
Added Custom client support and defined it in HDFS CLI config using "autoload.paths" variable
Modified README